### PR TITLE
chore(registry): sync server.json to 1.2.2

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/livetennisapi/livetennisapi-mcp",
     "source": "github"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "websiteUrl": "https://livetennisapi.com",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "livetennisapi-mcp",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bumps server.json (top-level + npm package version) from 1.2.1 to 1.2.2 to match the published npm release. Version 1.2.2 was published to the official MCP Registry (registry.modelcontextprotocol.io) as io.github.livetennisapi/livetennisapi-mcp and is now the latest active version.
